### PR TITLE
Change File to Filename in Function Comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ point to a remote syslog Server or local file or default log-rotated log file.
 
 ```
            Apply Configuration to XR using a file 
-           :param file: Filepath for a config file
+           :param filename: Filepath for a config file
                         with the following structure: 
                         !
                         XR config command
@@ -176,7 +176,7 @@ point to a remote syslog Server or local file or default log-rotated log file.
 ```
            Replace XR Configuration using a file
 
-           :param file: Filepath for a config file
+           :param filename: Filepath for a config file
                         with the following structure:
 
                         !

--- a/lib/ztp_helper.py
+++ b/lib/ztp_helper.py
@@ -342,7 +342,7 @@ class ZtpHelpers(object):
     def xrapply(self, filename=None, reason=None):
         """Apply Configuration to XR using a file 
           
-           :param file: Filepath for a config file
+           :param filename: Filepath for a config file
                         with the following structure: 
 
                         !
@@ -478,7 +478,7 @@ class ZtpHelpers(object):
     def xrreplace(self, filename=None):
         """Replace XR Configuration using a file 
           
-           :param file: Filepath for a config file
+           :param filename: Filepath for a config file
                         with the following structure: 
 
                         !


### PR DESCRIPTION
In `xrreplace` and in `xrapply` the comments refer to use "file" as a keyword argument whereas the actual function signature is "filename". Seems to be a minor typo, but I was using the comment to write my initial spec using keyword args, and almost missed it.

**Changes:**
- Updated ztp_helper and readme.md references

Regardless, the helpers are super useful, thanks a lot :)